### PR TITLE
Fix "redefinition of Base.read" warning

### DIFF
--- a/src/Source.jl
+++ b/src/Source.jl
@@ -9,12 +9,6 @@ Data.isdone(io::CSV.Source) = eof(io.data)
 # Data.getrow(io::CSV.Source) = readsplitline(io,io.options.delim,io.options.quotechar,io.options.escapechar)
 Base.readline(io::CSV.Source) = readline(io,io.options.quotechar,io.options.escapechar)
 
-@inline function Base.read(from::Base.AbstractIOBuffer, ::Type{UInt8})
-    @inbounds byte = from.data[from.ptr]
-    from.ptr += 1
-    return byte
-end
-
 # Constructors
 # independent constructor
 """

--- a/src/io.jl
+++ b/src/io.jl
@@ -1,3 +1,17 @@
+if VERSION < v"0.4.1"
+  @inline function Base.read(from::Base.AbstractIOBuffer, ::Type{UInt8})
+      ptr = from.ptr
+      size = from.size
+      from.readable || throw(ArgumentError("read failed, IOBuffer is not readable"))
+      if ptr > size
+          throw(EOFError())
+      end
+      @inbounds byte = from.data[ptr]
+      from.ptr = ptr + 1
+      return byte
+  end
+end
+
 "read a single line from `io` (any `IO` type) as a string, accounting for potentially embedded newlines in quoted fields (e.g. value1, value2, \"value3 with \n embedded newlines\"). Can optionally provide a `buf::IOBuffer` type for buffer resuse"
 function Base.readline(io::IO,q::UInt8,e::UInt8,buf::IOBuffer=IOBuffer())
     while !eof(io)


### PR DESCRIPTION
- move Base.read redefinition to io.jl
- update it based on Julia source code,
- only use it when VERSION < 0.4.1