### PR TITLE
use dirname(@__FILE__) rather than Pkg.dir

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 reload("CSV")
 using Base.Test, DataFrames, NullableArrays, DataStreams, WeakRefStrings
 
-dir = joinpath(Pkg.dir("CSV"),"test/test_files/")
+dir = joinpath(dirname(@__FILE__),"test_files/")
 
 #test on non-existent file
 @test_throws ArgumentError CSV.Source("");


### PR DESCRIPTION
never use `Pkg.dir` in a package to refer to its own location, that prevents
installing and using the package from anywhere else